### PR TITLE
Make text in search button visible again

### DIFF
--- a/app/templates/errors/404.jinja
+++ b/app/templates/errors/404.jinja
@@ -7,7 +7,7 @@
 
         <input class="search-form__text-input" type="text" name="q" value="{{ form.q.value() }}" placeholder="Enter your search term">
         <button class="btn" type="submit">
-          <span class="visually-hidden">{{_('Search')}}</span>
+          {{_('Search')}}
         </button>
       </div>
     </header>

--- a/app/templates/search/results.jinja
+++ b/app/templates/search/results.jinja
@@ -7,7 +7,7 @@
 
         <input class="search-form__text-input" type="text" name="q" value="{{ form.q.value() }}" placeholder="Enter your search term">
         <button class="btn" type="submit">
-          <span class="visually-hidden">{% trans %}Search{% endtrans %}</span>
+          {% trans %}Search{% endtrans %}
         </button>
       </div>
     </header>


### PR DESCRIPTION
A recent update to the CSS for a different purpose activated the `.visually-hidden` class that was used – but not needed – on the button.

Fixes #384