### PR TITLE
Display countries' oo_ongoing_work_body field instead of blurb

### DIFF
--- a/app/templates/views/region.jinja
+++ b/app/templates/views/region.jinja
@@ -51,7 +51,7 @@
 							{% endif %}
                     	{% endif %}
 
-						{{ country.blurb|richtext }}
+						{{ country.oo_ongoing_work_body|richtext }}
 						</div>
 					</li>
 				{% endfor %}


### PR DESCRIPTION
In the list of countries on Region pages.

For #350